### PR TITLE
Bug: Fixed `src/device.rs` pinning `std::os::raw::c_char` to `i8`.

### DIFF
--- a/src/device.rs
+++ b/src/device.rs
@@ -373,7 +373,7 @@ impl Device {
     /// ```
     pub fn uuid(self) -> CudaResult<[u8; 16]> {
         unsafe {
-            let mut cu_uuid = CUuuid { bytes: [0i8; 16] };
+            let mut cu_uuid = CUuuid { bytes: [0; 16] };
             cuDeviceGetUuid(&mut cu_uuid, self.device).to_result()?;
             let uuid: [u8; 16] = ::std::mem::transmute(cu_uuid.bytes);
             Ok(uuid)


### PR DESCRIPTION
In `aarch64` systems, it appear that `c_char` is `u8` instead. This allows Jetson Nano systems to correctly detect its GPU device.